### PR TITLE
output_preds_lists_to_dataframes_csvs.py now also updates relevancy and relevance dict of the newly created dataframes

### DIFF
--- a/utils/manually_analyzing_results.py
+++ b/utils/manually_analyzing_results.py
@@ -32,7 +32,7 @@ if tp_or_fp not in ['tp', 'TP', 'fp', 'FP']:
 tp_or_fp_gt_path = sys.argv[2]
 if tp_or_fp in ['fp', 'FP']:
    # path to csv having false positive preds notes with demos. 
-   fp_preds_path = sys.argv[3]
+   fp_preds_note_with_demo_from_GT_path = sys.argv[3]
 # Path where result/output of this program is stored
 review_results_path = convert_path(tp_or_fp_gt_path)
 
@@ -40,7 +40,7 @@ print('review_results path generated : ', review_results_path)
 
 tp_or_fp_gt = pd.read_csv(tp_or_fp_gt_path)
 if tp_or_fp in ['fp', 'FP']:
-  fp_preds = pd.read_csv(fp_preds_path)
+  fp_preds_note_with_demo_from_GT = pd.read_csv(fp_preds_note_with_demo_from_GT_path)
 
 # Update results file if exists, else create a new one
 if os.path.exists(review_results_path):
@@ -52,7 +52,7 @@ if os.path.exists(review_results_path):
 else:
     print("Creating new result review file, as it does not exist.")
     # 'note_id_preds' needed since it might give some insights why mapping was done
-    review_results = pd.DataFrame(columns = ['note_id_gt', 'note_id_preds', 'reason']) if tp_or_fp in ["FP", "fp"] else pd.DataFrame(columns = ['note_id', 'reason'])
+    review_results = pd.DataFrame(columns = ['note_id_gt', 'reason']) if tp_or_fp in ["FP", "fp"] else pd.DataFrame(columns = ['note_id', 'reason'])
 
 # random sampling to prevent bias
 sample_tp_or_fp_gt = tp_or_fp_gt.sample(n=100)
@@ -71,10 +71,10 @@ for index, row in sample_tp_or_fp_gt.iterrows():
           print(str(row[['note_text\n']].iloc[0]))
           print(str(row[['Relevance_dict(handle None values properly)']].iloc[0]))
           if tp_or_fp in ['fp', 'FP']:
-            breakpoint()
             print("\n\nPreds note : \n")
-            print(fp_preds['note_text\n'])
-          print("for investigation...")
+            print(fp_preds_note_with_demo_from_GT.iloc[index]['note_text\n'])
+            print(fp_preds_note_with_demo_from_GT.iloc[index]['Relevance_dict(handle None values properly)'])
+          print("\nfor investigation...\n\n")
           reason = input("Possible factors contributing to the mapping: ")
-          review_results.loc[len(review_results)] = [row['note_id'], reason] if tp_or_fp not in ['fp', 'FP'] else [row['note_id'], fp_preds[fp_preds['note_id'] == row['note_id']]['note_id'], reason]
+          review_results.loc[len(review_results)] = [row['note_id'], reason]
           review_results.to_csv(review_results_path, index=False)

--- a/utils/manually_analyzing_results.py
+++ b/utils/manually_analyzing_results.py
@@ -68,7 +68,7 @@ for index, row in sample_tp_or_fp_gt.iterrows():
           print(row.drop(['note_text\n', 'Relevance_dict(handle None values properly)']))
           if tp_or_fp in ['fp', 'FP']:
             print("\n\nGT note : \n")
-          print(str(row[['note_text\n']].iloc[0]), str(row[['note_text\n']].iloc[0]))
+          print(str(row[['note_text\n']].iloc[0]))
           print(str(row[['Relevance_dict(handle None values properly)']].iloc[0]))
           if tp_or_fp in ['fp', 'FP']:
             breakpoint()
@@ -76,5 +76,5 @@ for index, row in sample_tp_or_fp_gt.iterrows():
             print(fp_preds['note_text\n'])
           print("for investigation...")
           reason = input("Possible factors contributing to the mapping: ")
-          review_results.loc[len(review_results_fp)] = [row['note_id'], reason] if tp_or_fp not in ['fp', 'FP'] else [row['note_id'], fp_preds[fp_preds['note_id'] == row['note_id']]['note_id'], reason]
+          review_results.loc[len(review_results)] = [row['note_id'], reason] if tp_or_fp not in ['fp', 'FP'] else [row['note_id'], fp_preds[fp_preds['note_id'] == row['note_id']]['note_id'], reason]
           review_results.to_csv(review_results_path, index=False)

--- a/utils/manually_analyzing_results.py
+++ b/utils/manually_analyzing_results.py
@@ -62,17 +62,19 @@ for index, row in sample_tp_or_fp_gt.iterrows():
           if row['note_id'] in list((review_results['note_id_gt'] if tp_or_fp in ['fp', 'FP'] else review_results['note_id'])):
               print("note_id already done. Moving to the next one!")
               continue
+          if tp_or_fp in ['fp', 'FP']:
+            print("\n\nGT demos : \n")
           # Prevent relevant demos and note for investigation
           print(row.drop(['note_text\n', 'Relevance_dict(handle None values properly)']))
           if tp_or_fp in ['fp', 'FP']:
-            print("\n\nGT demo and note : \n")
+            print("\n\nGT note : \n")
           print(str(row[['note_text\n']].iloc[0]), str(row[['note_text\n']].iloc[0]))
           print(str(row[['Relevance_dict(handle None values properly)']].iloc[0]))
           if tp_or_fp in ['fp', 'FP']:
+            breakpoint()
             print("\n\nPreds note : \n")
-            print(fp_preds[fp_preds['note_id'] == row['note_id']]['note_text\n'])
+            print(fp_preds['note_text\n'])
           print("for investigation...")
-          breakpoint()
           reason = input("Possible factors contributing to the mapping: ")
           review_results.loc[len(review_results_fp)] = [row['note_id'], reason] if tp_or_fp not in ['fp', 'FP'] else [row['note_id'], fp_preds[fp_preds['note_id'] == row['note_id']]['note_id'], reason]
           review_results.to_csv(review_results_path, index=False)

--- a/utils/output_preds_lists_to_dataframes_csvs.py
+++ b/utils/output_preds_lists_to_dataframes_csvs.py
@@ -33,6 +33,9 @@ def save_preds():
     p_data_df_incorrect_GT = p_data_df[p_data_df['person_id'].isin(listIndsOfRowsIncorrectGT)] # those rows of p_data_df whose person_ids are incorrectly mapped i.e false positive GT
     p_data_df_indexes_for_values_of_false_positives_GT_to_preds_indices_dict = [p_data_df.index[p_data_df['person_id'] == false_positives_GT_to_preds_indices_dict[i]][0] for i in p_data_df_incorrect_GT['person_id']] # indices of those rows of p_data_df, whose person_ids are what incorrectly mapped person_ids are mapped to.
     p_data_df_incorrect_preds = p_data_df.loc[p_data_df_indexes_for_values_of_false_positives_GT_to_preds_indices_dict] # those rows of p_data_df, whose person_ids are what incorrectly mapped person_ids are mapped to.
+    p_data_df_incorrect_preds_note_text_with_GT_demo = pd.DataFrame(p_data_df_incorrect_GT) # demo of incorrect_GT with notes of incorrect_preds. notes are put in below. This DataFrame is useful when analyzing false positives.
+    p_data_df_incorrect_preds_note_text_with_GT_demo['note_text\n'] = list(p_data_df_incorrect_preds['note_text\n'])
+    p_data_df_incorrect_preds_note_text_with_GT_demo['original_note_text\n'] = list(p_data_df_incorrect_preds['original_note_text\n'])
 
     tpDirList = true_positives_path.split("/") # directories of true positives' path
     fpGTDirList = false_positives_GT_path.split("/") # directories of false positives' GT path
@@ -40,19 +43,23 @@ def save_preds():
     tpNewPath = os.path.join("/".join(tpDirList[:-1]), tpDirList[-1].split(".")[-2] + ".csv") # loc of the new file
     fpGTNewPath = os.path.join("/".join(fpGTDirList[:-1]), fpGTDirList[-1].split(".")[-2] + ".csv") # loc of the new file
     fpPredsNewPath = os.path.join("/".join(fpPredsDirList[:-1]), fpPredsDirList[-1].split(".")[-2] + ".csv") # loc of the new file
+    fpPredsNotesWithGTDemoPath = os.path.join("/".join(fpPredsDirList[:-1]), fpPredsDirList[-1].split(".")[-2] + "_notes_with_demo_of_GT.csv") # loc of the new file
 
     # Updating relevancy and relvance dicts of the dataframes just created
     p_data_df_correct = process_data(p_data_df_correct)
     p_data_df_incorrect_GT = process_data(p_data_df_incorrect_GT)
     p_data_df_incorrect_preds = process_data(p_data_df_incorrect_preds)
+    p_data_df_incorrect_preds_note_text_with_GT_demo = process_data(p_data_df_incorrect_preds_note_text_with_GT_demo)
  
     p_data_df_correct.reset_index(drop=True).to_csv(tpNewPath, index_label=False)
     p_data_df_incorrect_GT.reset_index(drop=True).to_csv(fpGTNewPath, index_label=False)
     p_data_df_incorrect_preds.reset_index(drop=True).to_csv(fpPredsNewPath, index_label=False)
+    p_data_df_incorrect_preds_note_text_with_GT_demo.reset_index(drop=True).to_csv(fpPredsNotesWithGTDemoPath, index_label=False)
  
-    print("Correct preds file new path : ", tpNewPath)
-    print("Incorrect preds GT file new path : ", fpGTNewPath)
-    print("Incorrect preds preds file new path : ", fpPredsNewPath)
+    print("Correct preds file's new path : ", tpNewPath)
+    print("Incorrect preds GT file's new path : ", fpGTNewPath)
+    print("Incorrect preds preds file's new path : ", fpPredsNewPath)
+    print("Incorrect preds preds notes with demo of GT file's new path : ", fpPredsNotesWithGTDemoPath)
 
 if __name__ == "__main__":
     save_preds()

--- a/utils/output_preds_lists_to_dataframes_csvs.py
+++ b/utils/output_preds_lists_to_dataframes_csvs.py
@@ -6,6 +6,7 @@ import os
 import datasets
 import sys
 import numpy as np
+from update_or_create_relevancy_and_relevance_dict import process_data
 
 def save_preds():
 
@@ -21,17 +22,17 @@ def save_preds():
     print("dataset_path(parquet format) given : ", dataset_path)
     
     # Convert .npy list of person_ids to python list of person_ids    
-    listIndsOfRowsCorrect = [int(i) for i in np.load(true_positives_path).tolist()] 
-    listIndsOfRowsIncorrectGT = [int(i) for i in np.load(false_positives_GT_path).tolist()] 
-    listIndsOfRowsIncorrectPreds = [int(i) for i in np.load(false_positives_preds_path).tolist()] 
-
+    listIndsOfRowsCorrect = [int(i) for i in np.load(true_positives_path).tolist()]  # True postivies person_ids, in the form of python list
+    listIndsOfRowsIncorrectGT = [int(i) for i in np.load(false_positives_GT_path).tolist()] # False positives GT person_ids, in the form of python list
+    listIndsOfRowsIncorrectPreds = [int(i) for i in np.load(false_positives_preds_path).tolist()] # False positives Preds person_ids, in the form of python list
+    
+    false_positives_GT_to_preds_indices_dict = dict(zip(listIndsOfRowsIncorrectGT, listIndsOfRowsIncorrectPreds)) # Maps incorrect GT indexes to corresponding preds indexes
 
     p_data_df = datasets.Dataset.from_parquet(dataset_path).to_pandas()
-    p_data_df_correct = p_data_df[p_data_df['person_id'].isin(listIndsOfRowsCorrect)]
-    p_data_df_incorrect_GT = p_data_df[p_data_df['person_id'].isin(listIndsOfRowsIncorrectGT)]
-    p_data_df_incorrect_preds = p_data_df[p_data_df['person_id'].isin(listIndsOfRowsIncorrectPreds)]
-
-
+    p_data_df_correct = p_data_df[p_data_df['person_id'].isin(listIndsOfRowsCorrect)] # those rows of p_data_df whose person ids are correctly mapped i.e true positive
+    p_data_df_incorrect_GT = p_data_df[p_data_df['person_id'].isin(listIndsOfRowsIncorrectGT)] # those rows of p_data_df whose person_ids are incorrectly mapped i.e false positive GT
+    p_data_df_indexes_for_values_of_false_positives_GT_to_preds_indices_dict = [p_data_df.index[p_data_df['person_id'] == false_positives_GT_to_preds_indices_dict[i]][0] for i in p_data_df_incorrect_GT['person_id']] # indices of those rows of p_data_df, whose person_ids are what incorrectly mapped person_ids are mapped to.
+    p_data_df_incorrect_preds = p_data_df.loc[p_data_df_indexes_for_values_of_false_positives_GT_to_preds_indices_dict] # those rows of p_data_df, whose person_ids are what incorrectly mapped person_ids are mapped to.
 
     tpDirList = true_positives_path.split("/") # directories of true positives' path
     fpGTDirList = false_positives_GT_path.split("/") # directories of false positives' GT path
@@ -39,6 +40,11 @@ def save_preds():
     tpNewPath = os.path.join("/".join(tpDirList[:-1]), tpDirList[-1].split(".")[-2] + ".csv") # loc of the new file
     fpGTNewPath = os.path.join("/".join(fpGTDirList[:-1]), fpGTDirList[-1].split(".")[-2] + ".csv") # loc of the new file
     fpPredsNewPath = os.path.join("/".join(fpPredsDirList[:-1]), fpPredsDirList[-1].split(".")[-2] + ".csv") # loc of the new file
+
+    # Updating relevancy and relvance dicts of the dataframes just created
+    p_data_df_correct = process_data(p_data_df_correct)
+    p_data_df_incorrect_GT = process_data(p_data_df_incorrect_GT)
+    p_data_df_incorrect_preds = process_data(p_data_df_incorrect_preds)
  
     p_data_df_correct.reset_index(drop=True).to_csv(tpNewPath, index_label=False)
     p_data_df_incorrect_GT.reset_index(drop=True).to_csv(fpGTNewPath, index_label=False)

--- a/utils/update_or_create_relevancy_and_relevance_dict.py
+++ b/utils/update_or_create_relevancy_and_relevance_dict.py
@@ -6,16 +6,6 @@ import datasets
 import transformers
 import sys
 
-print("THIS FILE OVERWRITES THE GIVEN ORIGINAL FILE, ARE YOU OKAY WITH IT? Type 'Y' or 'N'")
-response = input()
-if response != 'Y' and response != 'N':
-    print("Invalid Input.")
-    exit(0)
-
-# Configuration variables
-input_filepath = sys.argv[1]
-print("input_filepath : ", input_filepath)
-
 # Function to process your data
 # @ profile
 def process_data(df):
@@ -129,6 +119,16 @@ def process_data(df):
     
     return df
 
-df = pd.read_csv(input_filepath)
-processed_df = process_data(df)
-processed_df.to_csv(input_filepath)
+if __name__ == "__main__":
+    print("THIS FILE OVERWRITES THE GIVEN ORIGINAL FILE, ARE YOU OKAY WITH IT? Type 'Y' or 'N'")
+    response = input()
+    if response != 'Y' and response != 'N':
+        print("Invalid Input.")
+        exit(0)
+    
+    # Configuration variables
+    input_filepath = sys.argv[1]
+    print("input_filepath : ", input_filepath)
+    df = pd.read_csv(input_filepath)
+    processed_df = process_data(df)
+    processed_df.to_csv(input_filepath)


### PR DESCRIPTION
output_preds_lists_to_dataframes_csvs.py now also updates relevancy and relevance dict of the newly created dataframes

manually_analyzing_results.py file handles tp as well as fp options, therefore not needing separate python scripts for those two highly similar options.

manually_analyzing_results.py syntax error resolved

output_preds_lists_to_dataframes_csvs.py now also produces dataframe having incorrect preds's note with GT's demo

minor bugs in manually_analyzing_results.py resolved. Program now also prints relevant dict for the predicted note, not just that of GT note.